### PR TITLE
(fix) Consider client timezone on appointment service dates

### DIFF
--- a/src/models/appointmentService.js
+++ b/src/models/appointmentService.js
@@ -10,7 +10,14 @@ Bahmni.Appointments.AppointmentService = (function () {
         var dateUtil = Bahmni.Common.Util.DateUtil;
 
         var getTime = function (dateTime) {
-            return dateTime ? dateUtil.getDateTimeInSpecifiedFormat(dateTime, timeFormat) : undefined;
+            if (!dateTime) {
+                return undefined;
+            }
+            let now = new Date();
+            now.setHours(dateTime.getHours());
+            now.setMinutes(dateTime.getMinutes());
+            now.setSeconds(dateTime.getSeconds());
+            return ('0' + now.getUTCHours()).slice(-2) + ':' + ('0' + now.getUTCMinutes()).slice(-2) + ':' + ('0' + now.getUTCSeconds()).slice(-2);
         };
 
         var constructAvailabilityPerDay = function (result, availability) {

--- a/src/models/appointmentService.js
+++ b/src/models/appointmentService.js
@@ -17,7 +17,10 @@ Bahmni.Appointments.AppointmentService = (function () {
             now.setHours(dateTime.getHours());
             now.setMinutes(dateTime.getMinutes());
             now.setSeconds(dateTime.getSeconds());
-            return ('0' + now.getUTCHours()).slice(-2) + ':' + ('0' + now.getUTCMinutes()).slice(-2) + ':' + ('0' + now.getUTCSeconds()).slice(-2);
+            const hours = ('0' + now.getUTCHours()).slice(-2);
+            const minutes = ('0' + now.getUTCMinutes()).slice(-2);
+            const seconds = ('0' + now.getUTCSeconds()).slice(-2);
+            return `${hours}:${minutes}:${seconds}`;
         };
 
         var constructAvailabilityPerDay = function (result, availability) {

--- a/src/models/appointmentServiceViewModel.js
+++ b/src/models/appointmentServiceViewModel.js
@@ -30,7 +30,15 @@ Bahmni.Appointments.AppointmentServiceViewModel = (function () {
 
     Service.createFromResponse = function (serviceDetails) {
         var getDateTime = function (time) {
-            return time ? new Date("January 01, 1970 " + time) : undefined;
+            if (!time) {
+                return undefined;
+            }
+            let date = new Date();
+            date.setHours(time.split(':')[0]);
+            date.setMinutes(time.split(':')[1]);
+            date.setSeconds(time.split(':')[2]);
+            date.setMilliseconds(0);
+            return date;
         };
 
         var parseAvailability = function (avbsByDay) {

--- a/src/models/appointmentServiceViewModel.js
+++ b/src/models/appointmentServiceViewModel.js
@@ -33,11 +33,9 @@ Bahmni.Appointments.AppointmentServiceViewModel = (function () {
             if (!time) {
                 return undefined;
             }
+            const [hours, minutes, seconds = 0] = time.split(':').map(Number);
             let date = new Date();
-            date.setHours(time.split(':')[0]);
-            date.setMinutes(time.split(':')[1]);
-            date.setSeconds(time.split(':')[2]);
-            date.setMilliseconds(0);
+            date.setUTCHours(hours, minutes, seconds, 0);
             return date;
         };
 

--- a/test/controllers/admin/appointmentServiceController.spec.js
+++ b/test/controllers/admin/appointmentServiceController.spec.js
@@ -176,8 +176,10 @@ describe("AppointmentServiceController", function () {
             var dateUtil = Bahmni.Common.Util.DateUtil;
             var timeFormat = 'HH:mm:ss';
             beforeEach(function () {
-                startDateTime = new Date('1970-01-01T11:30:00.000Z');
-                endDateTime = new Date('1970-01-01T14:30:00.000Z');
+                startDateTime = new Date();
+                startDateTime.setHours(11, 30, 0);
+                endDateTime = new Date();
+                startDateTime.setHours(14, 30, 0);
                 serviceResponse = {
                     startTime: dateUtil.getDateTimeInSpecifiedFormat(startDateTime, timeFormat),
                     endTime: dateUtil.getDateTimeInSpecifiedFormat(endDateTime, timeFormat),
@@ -234,12 +236,12 @@ describe("AppointmentServiceController", function () {
             scope.service = {
                 name: 'Chemotherapy',
                 description: 'For cancer',
-                startTime: new Date().toString(),
-                endTime: new Date().toString(),
+                startTime: new Date(),
+                endTime: new Date(),
                 initialAppointmentStatus: 'Requested',
                 weeklyAvailability: [{
-                    startTime: new Date().toString(),
-                    endTime: new Date().toString(),
+                    startTime: new Date(),
+                    endTime: new Date(),
                     days: [{name: 'MONDAY', isSelected: true}]
                 }]
             };

--- a/test/models/AppointmentServiceViewModel.spec.js
+++ b/test/models/AppointmentServiceViewModel.spec.js
@@ -4,8 +4,10 @@ describe('AppointmentServiceViewModel', function () {
     var appointmentServiceModel;
     var dateUtil = Bahmni.Common.Util.DateUtil;
     var timeFormat = 'HH:mm:ss';
-    var startDateTime = new Date('1970-01-01T11:30:00.000Z');
-    var endDateTime = new Date('1970-01-01T14:30:00.000Z');
+    var startDateTime = new Date();
+    startDateTime.setHours(11, 30, 0);
+    var endDateTime = new Date();
+    startDateTime.setHours(14, 30, 0);
 
     var serviceResponse = {
         name: 'Ortho',

--- a/test/models/appointmentService.spec.js
+++ b/test/models/appointmentService.spec.js
@@ -54,8 +54,8 @@ describe('AppointmentService', function () {
     });
 
     it('should re arrange all weeklyAvailabilities by day', function () {
-        var startDateTime = new Date().toString();
-        var endDateTime = new Date().toString();
+        var startDateTime = new Date();
+        var endDateTime = new Date();
 
         var days = angular.copy(constDays);
         days[1].isSelected = true;
@@ -80,11 +80,11 @@ describe('AppointmentService', function () {
     });
 
     it('should construct weekly availability by day for multiple availabilities', function () {
-        var startDateTime = new Date().toString();
-        var endDateTime = new Date().toString();
+        var startDateTime = new Date();
+        var endDateTime = new Date();
 
-        var startDateTime2 = new Date("2015-10-01T18:30:00.000Z").toString();
-        var endDateTime2 = new Date("2015-10-01T18:30:00.000Z").toString();
+        var startDateTime2 = new Date("2015-10-01T18:30:00.000Z");
+        var endDateTime2 = new Date("2015-10-01T18:30:00.000Z");
 
         var days1 = angular.copy(constDays);
         days1[1].isSelected = true;


### PR DESCRIPTION
How it's working with this development:

1. On the client, my timezone is GMT+1. I create a service available from 09:00 AM to 11:30 AM:

![image](https://github.com/icrc/openmrs-module-appointments-frontend/assets/68599335/4fcf2029-f9e8-4856-9206-fa3c90ad1ae9)

2. The service get's saved into DB with the times in UTC (08:00 AM to 10:30 AM):

![image](https://github.com/icrc/openmrs-module-appointments-frontend/assets/68599335/c972912e-1e67-418a-a0f0-f0a66ded9cde)

3. My timezone is GMT+1 and I try to create an appointment outside of the service availability (11:30 AM to 12:00 AM) - not available as expected:

![image](https://github.com/icrc/openmrs-module-appointments-frontend/assets/68599335/60d2736b-fe9a-43ec-ae6b-71dc8f8a1ff8)

4. My timezone is GMT+1 and I try to create an appointment inside of the service availability window (11:00 AM to 11:30 AM) . ok:

![image](https://github.com/icrc/openmrs-module-appointments-frontend/assets/68599335/e54b1d77-1059-47c0-8b76-1a2eb64d71b1)

5. But if my timezone is GMT+0, I can create an appointment from 08:30 AM to 09:00 AM because the service, in my timezone, it's available from 08:00 AM to 10:30 AM (**is this the expected?**):

![image](https://github.com/icrc/openmrs-module-appointments-frontend/assets/68599335/4aa9d8c8-469f-4ed6-bbef-a1b9de7c7127)